### PR TITLE
fix: upgrade rustls-webpki to 0.103.13, 0.104.0-alpha.7 (GHSA-82j2-j2ch-gfr8)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3522,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Upgrade rustls-webpki from 0.103.8 to 0.103.13, 0.104.0-alpha.7 to fix GHSA-82j2-j2ch-gfr8.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-82j2-j2ch-gfr8 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-82j2-j2ch-gfr8` |
| **File** | `src-tauri/Cargo.lock` (dependency: `rustls-webpki`) |
| **Assessment** | Defensive hardening |

**Description**: rustls-webpki: Denial of service via panic on malformed CRL BIT STRING

## Changes
- `src-tauri/Cargo.lock`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
